### PR TITLE
fix(app): starting up failure with errors

### DIFF
--- a/bennuhp/templates/bennuhp/common/base.html
+++ b/bennuhp/templates/bennuhp/common/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load staticfiles %}
+{% load static %}
 <html lang="en">
     <head>
         <meta charset="utf-8">

--- a/bennuhp/urls.py
+++ b/bennuhp/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import path
 from django.conf import settings
 from django.conf.urls.static import static
 
 from . import views
 
 urlpatterns = [
-    url(r'^home/', views.home, name='hm'),
-    url(r'^biography/', views.biography, name='bio'),
-    url(r'^discography/', views.discograpth, name='dsk'),
-    url(r'^lives/', views.lives, name='lv'),
+    path('home/', views.home, name='hm'),
+    path('biography/', views.biography, name='bio'),
+    path('discography/', views.discograpth, name='dsk'),
+    path('lives/', views.lives, name='lv'),
 ]
 
 if settings.DEBUG:

--- a/bennuofficial/urls.py
+++ b/bennuofficial/urls.py
@@ -1,13 +1,14 @@
 from django.contrib import admin
-from django.conf.urls import include, url
-from django.conf import settings
-from django.conf.urls.static import static
+from django.conf.urls import include
+from django.urls import path
+# from django.conf import settings
+# from django.conf.urls.static import static
 
-from bennuhp.views import page_not_found
+# from bennuhp.views import page_not_found
 
 urlpatterns = [
-    url('^admin/', admin.site.urls),
-    url('', include('bennuhp.urls')),
+    path('admin/', admin.site.urls),
+    path('', include('bennuhp.urls')),
     # url(r'^', page_not_found),
 ]
 


### PR DESCRIPTION
# Issue link
Closes #27 

# What does this PR do?
- Fixed ImportError with replacement of `django.conf.urls.url()`
- Fixed TemplateSyntaxError on application startup
  - As after fixing ImportError above, we hit the TemplateSyntaxError and 500 Error like the following output.
  - This is because `{% load staticfiles %}` could not be applied with Django 3.0 or later, and need to fix with `{% load static %}`
  - Ref: `django.contrib.staticfiles.templatetags.staticfiles.static() is removed.` in [official release notes](https://docs.djangoproject.com/en/4.2/releases/3.0/#features-removed-in-3-0)

```bash
% python manage.py runserver
INFO:django.utils.autoreload:Watching for file changes with StatReloader
Performing system checks...
# (...)
System check identified 1 issue (0 silenced).
December 17, 2023 - 23:30:00
Django version 5.0, using settings 'bennuofficial.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.

ERROR:django.request:Internal Server Error: /home/
Traceback (most recent call last):
  File "/Users/hwakabayashi/git/bennu-official-hp/.venv/lib/python3.11/site-packages/django/template/defaulttags.py", line 1033, in find_library
    return parser.libraries[name]
           ~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'staticfiles'
# (...)
django.template.exceptions.TemplateSyntaxError: 'staticfiles' is not a registered tag library. Must be one of:
admin_list
admin_modify
admin_urls
cache
i18n
l10n
log
static
tz
[17/Dec/2023 23:30:05] "GET /home/ HTTP/1.1" 500 145
```


# What does not include in this PR?
N/A
